### PR TITLE
Fix package installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
-from distutils.core import setup
+from setuptools import setup, find_packages
 
 setup(name='seeing',
       version='1.0',
-      py_modules=['seeing'],
+      packages=find_packages(),
       )


### PR DESCRIPTION
Use setuptools and `find_packages` to correctly detect and install the `seeing` package.
`py_modules` is only to install a single module (i.e. a `seeing.py` file). See installation log:
```
  Running command python setup.py egg_info
  file seeing.py (for module seeing) not found
```
Also distutils is deprecated with removal planned for Python 3.12, so better use setuptools instead.